### PR TITLE
Dismiss keyboard when editor is not visible

### DIFF
--- a/Industrious.ToDo.Forms/App.xaml.cs
+++ b/Industrious.ToDo.Forms/App.xaml.cs
@@ -24,19 +24,37 @@ namespace Industrious.ToDo.Forms
 		}
 
 
-		public Page CurrentPage => ((NavigationPage)MainPage).CurrentPage;
+		public ContentPage CurrentPage => (ContentPage)((NavigationPage)MainPage).CurrentPage;
 
 
-		public void DismissEditorPage()
+		public void DismissEditor()
 		{
-			if (!ShouldSplitScreen() && CurrentPage is ItemEditorPage)
+			if (IsSplitScreen)
+			{
+				var splitView = (SplitView)CurrentPage.Content;
+				splitView.RightContent = new NoItemSelectedView();
+			}
+			else if (CurrentPage is ItemEditorPage)
+			{
 				MainPage.Navigation.PopAsync();
+			}
 		}
 
 
-		public void ShowEditorPage()
+		public void ShowEditor()
 		{
-			if (!ShouldSplitScreen() && !(CurrentPage is ItemEditorPage))
+			if (IsSplitScreen)
+			{
+				var splitView = (SplitView)CurrentPage.Content;
+				if (!(splitView.RightContent is ItemEditorView))
+				{
+					splitView.RightContent = new ItemEditorView()
+					{
+						BindingContext = new ItemEditorViewModel(this, _appState)
+					};
+				}
+			}
+			else if (!(CurrentPage is ItemEditorPage))
 			{
 				MainPage.Navigation.PushAsync(new ItemEditorPage()
 				{
@@ -55,7 +73,7 @@ namespace Industrious.ToDo.Forms
 
 		private Page CreateMainPage()
 		{
-			return (ShouldSplitScreen())
+			return (IsSplitScreen)
 				? CreateMainTwoColumnPage()
 				: CreateMainOneColumnPage();
 		}
@@ -83,10 +101,7 @@ namespace Industrious.ToDo.Forms
 				{
 					BindingContext = new ItemListViewModel(this, _appState)
 				},
-				RightContent = new ItemEditorView()
-				{
-					BindingContext = new ItemEditorViewModel(this, _appState)
-				}
+				RightContent = new NoItemSelectedView()
 			});
 		}
 
@@ -94,17 +109,20 @@ namespace Industrious.ToDo.Forms
 		/// <summary>
 		///  Decide if the device screen is large enough to support the two-column view.
 		/// </summary>
-		private Boolean ShouldSplitScreen()
+		private Boolean IsSplitScreen
 		{
-			switch (Device.Idiom)
+			get
 			{
-			case TargetIdiom.Tablet:
-			case TargetIdiom.Desktop:
-			case TargetIdiom.TV:
-				return (true);
+				switch (Device.Idiom)
+				{
+				case TargetIdiom.Tablet:
+				case TargetIdiom.Desktop:
+				case TargetIdiom.TV:
+					return (true);
 
-			default:
-				return (false);
+				default:
+					return (false);
+				}
 			}
 		}
 

--- a/Industrious.ToDo.Forms/ItemEditorView.xaml
+++ b/Industrious.ToDo.Forms/ItemEditorView.xaml
@@ -4,47 +4,36 @@
 			 xmlns:forms="clr-namespace:Industrious.Forms;assembly=Industrious.Forms"
 			 x:Class="Industrious.ToDo.Forms.ItemEditorView">
 	<StackLayout Margin="20,20">
-		<StackLayout IsVisible="{forms:BooleanBinding SelectedItem}">
-			<Entry Text="{Binding Title}"
-				   TextChanged="OnTitleChanged"
-				   Placeholder="Title" />
-			<OnPlatform x:TypeArguments="View">
-				<On Platform="Android">
+		<Entry Text="{Binding Title}"
+			   TextChanged="OnTitleChanged"
+			   Placeholder="Title" />
+		<OnPlatform x:TypeArguments="View">
+			<On Platform="Android">
+				<Editor Text="{Binding Notes}"
+						TextChanged="OnNotesChanged"
+						Placeholder="Notes"
+						HeightRequest="100" />
+			</On>
+			<On Platform="iOS">
+				<Frame BorderColor="#e7e7e7"
+					   HasShadow="false"
+					   Padding="4,4">
 					<Editor Text="{Binding Notes}"
 							TextChanged="OnNotesChanged"
 							Placeholder="Notes"
+							PlaceholderColor="#b5b5b5"
 							HeightRequest="100" />
-				</On>
-				<On Platform="iOS">
-
-					<Frame BorderColor="#e7e7e7"
-						   HasShadow="false"
-						   Padding="4,4">
-						<Editor Text="{Binding Notes}"
-								TextChanged="OnNotesChanged"
-								Placeholder="Notes"
-								PlaceholderColor="#b5b5b5"
-								HeightRequest="100" />
-					</Frame>
-				</On>
-			</OnPlatform>
-			<StackLayout Orientation="Horizontal">
-				<Switch IsToggled="{Binding IsComplete}"
-						Toggled="OnIsCompleteToggled"
-						HorizontalOptions="Start"
-						VerticalOptions="Center" />
-				<Label Text="Completed"
-					   HorizontalOptions="FillAndExpand"
-					   VerticalOptions="Center" />
-			</StackLayout>
-		</StackLayout>
-		<StackLayout VerticalOptions="CenterAndExpand"
-					 IsVisible="{forms:BooleanBinding !SelectedItem}">
-			<Label Text="No Item Selected"
-				   FontSize="Large"
-				   TextColor="Gray"
-				   HorizontalOptions="CenterAndExpand"
-				   VerticalOptions="CenterAndExpand" />
+				</Frame>
+			</On>
+		</OnPlatform>
+		<StackLayout Orientation="Horizontal">
+			<Switch IsToggled="{Binding IsComplete}"
+					Toggled="OnIsCompleteToggled"
+					HorizontalOptions="Start"
+					VerticalOptions="Center" />
+			<Label Text="Completed"
+				   HorizontalOptions="FillAndExpand"
+				   VerticalOptions="Center" />
 		</StackLayout>
 	</StackLayout>
 </ContentView>

--- a/Industrious.ToDo.Forms/NoItemSelectedView.xaml
+++ b/Industrious.ToDo.Forms/NoItemSelectedView.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Industrious.ToDo.Forms.NoItemSelectedView">
+	<StackLayout VerticalOptions="CenterAndExpand">
+		<Label Text="No Item Selected"
+			   FontSize="Large"
+			   TextColor="Gray"
+			   HorizontalOptions="CenterAndExpand"
+			   VerticalOptions="CenterAndExpand" />
+	</StackLayout>
+</ContentView>
+

--- a/Industrious.ToDo.Forms/NoItemSelectedView.xaml.cs
+++ b/Industrious.ToDo.Forms/NoItemSelectedView.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace Industrious.ToDo.Forms
+{
+	public partial class NoItemSelectedView : ContentView
+	{
+		public NoItemSelectedView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Industrious.ToDo.ViewModels.Tests/ItemEditorViewModelTests.cs
+++ b/Industrious.ToDo.ViewModels.Tests/ItemEditorViewModelTests.cs
@@ -246,5 +246,22 @@ namespace Industrious.ToDo.ViewModels.Tests
 				Assert.False(sut.IsComplete);
 			}
 		}
+
+
+		[Fact]
+		public void DismissesEditor_WhenNoItemSelected()
+		{
+			var navigator = new MockNavigator()
+			{
+				IsEditorVisible = true
+			};
+
+			_state.SelectItem(TestItems[0]);
+			using (var sut = new ItemEditorViewModel(navigator, _state))
+			{
+				_state.SelectItem(null);
+				Assert.False(navigator.IsEditorVisible);
+			}
+		}
 	}
 }

--- a/Industrious.ToDo.ViewModels.Tests/ItemListViewModelTests.cs
+++ b/Industrious.ToDo.ViewModels.Tests/ItemListViewModelTests.cs
@@ -35,7 +35,7 @@ namespace Industrious.ToDo.ViewModels.Tests
 
 
 		[Fact]
-		public void SelectItemCommand_NavigatesToEditor()
+		public void SelectItemCommand_NavigatesToEditor_WhenItemSelected()
 		{
 			var navigator = new MockNavigator()
 			{

--- a/Industrious.ToDo.ViewModels.Tests/MockNavigator.cs
+++ b/Industrious.ToDo.ViewModels.Tests/MockNavigator.cs
@@ -7,13 +7,13 @@ namespace Industrious.ToDo.ViewModels.Tests
 		public Boolean IsEditorVisible;
 
 
-		public void DismissEditorPage()
+		public void DismissEditor()
 		{
 			IsEditorVisible = false;
 		}
 
 
-		public void ShowEditorPage()
+		public void ShowEditor()
 		{
 			IsEditorVisible = true;
 		}

--- a/Industrious.ToDo.ViewModels/IAppNavigator.cs
+++ b/Industrious.ToDo.ViewModels/IAppNavigator.cs
@@ -4,8 +4,8 @@ namespace Industrious.ToDo.ViewModels
 {
 	public interface IAppNavigator
 	{
-		void DismissEditorPage();
+		void DismissEditor();
 
-		void ShowEditorPage();
+		void ShowEditor();
 	}
 }

--- a/Industrious.ToDo.ViewModels/ItemEditorViewModel.cs
+++ b/Industrious.ToDo.ViewModels/ItemEditorViewModel.cs
@@ -8,12 +8,15 @@ namespace Industrious.ToDo.ViewModels
 {
 	public class ItemEditorViewModel : NotifyPropertyChanged, IDisposable
 	{
+		private readonly IAppNavigator _appNavigator;
 		private readonly AppState _appState;
 
 
 		public ItemEditorViewModel(IAppNavigator appNavigator, AppState appState)
 		{
+			_appNavigator = appNavigator;
 			_appState = appState;
+
 			_appState.PropertyChanged += OnAppStatePropertyChanged;
 
 			OnSelectedItemChanged(_appState.SelectedItem);
@@ -22,7 +25,6 @@ namespace Industrious.ToDo.ViewModels
 			{
 				var item = appState.AddNewItem();
 				appState.SelectItem(item);
-				appNavigator.ShowEditorPage();
 			});
 
 			ChangeNotesCommand = new Command<String>(value =>
@@ -40,7 +42,7 @@ namespace Industrious.ToDo.ViewModels
 			DeleteItemCommand = new Command(() =>
 			{
 				appState.DeleteItem(SelectedItem);
-				appNavigator.DismissEditorPage();
+				appNavigator.DismissEditor();
 			});
 
 			ToggleCompleteCommand = new Command<Boolean>(value =>
@@ -130,12 +132,12 @@ namespace Industrious.ToDo.ViewModels
 				SelectedItem.PropertyChanged -= OnToDoItemPropertyChanged;
 
 			SelectedItem = newSelectedItem;
+			OnToDoItemPropertyChanged(null, null);
 
 			if (SelectedItem != null)
 				SelectedItem.PropertyChanged += OnToDoItemPropertyChanged;
-
-
-			OnToDoItemPropertyChanged(null, null);
+			else
+				_appNavigator.DismissEditor();
 		}
 
 

--- a/Industrious.ToDo.ViewModels/ItemListViewModel.cs
+++ b/Industrious.ToDo.ViewModels/ItemListViewModel.cs
@@ -16,7 +16,7 @@ namespace Industrious.ToDo.ViewModels
 				if (itemViewCellModel != null)
 				{
 					appState.SelectItem(itemViewCellModel.ToDoItem);
-					navigation.ShowEditorPage();
+					navigation.ShowEditor();
 				}
 				else
 				{

--- a/Industrious.ToDo.ViewModels/MainViewModel.cs
+++ b/Industrious.ToDo.ViewModels/MainViewModel.cs
@@ -17,7 +17,7 @@ namespace Industrious.ToDo.ViewModels
 			{
 				var item = appState.AddNewItem();
 				appState.SelectItem(item);
-				appNavigator.ShowEditorPage();
+				appNavigator.ShowEditor();
 			});
 
 			DeleteItemCommand = new Command(


### PR DESCRIPTION
The keyboard was staying visible, even when the "No Item Selected" view was shown, because the editor form was only hidden, not unloaded. Split the "No Item Selected" content out in its own view, and swap the views when no item is selected instead of just hiding the editor.