### PR TITLE
Set input focus to title field for new todos

### DIFF
--- a/Industrious.ToDo.Android/Industrious.ToDo.Android.csproj
+++ b/Industrious.ToDo.Android/Industrious.ToDo.Android.csproj
@@ -52,7 +52,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.2.0.815419" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />

--- a/Industrious.ToDo.Forms/Industrious.ToDo.Forms.csproj
+++ b/Industrious.ToDo.Forms/Industrious.ToDo.Forms.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.2.0.815419" />
-    <PackageReference Include="Industrious.Forms" Version="1.0.0" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
+    <PackageReference Include="Industrious.Forms" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Industrious.ToDo.ViewModels\Industrious.ToDo.ViewModels.csproj" />

--- a/Industrious.ToDo.Forms/Views/ItemEditorView.xaml
+++ b/Industrious.ToDo.Forms/Views/ItemEditorView.xaml
@@ -6,7 +6,8 @@
 	<StackLayout Margin="20,20">
 		<Entry Text="{Binding Title}"
 			   TextChanged="OnTitleChanged"
-			   Placeholder="Title" />
+			   Placeholder="Title"
+			   forms:AutoFocusBehavior.FocusWhen="{Binding ShouldFocusTitle}" />
 		<OnPlatform x:TypeArguments="View">
 			<On Platform="Android">
 				<Editor Text="{Binding Notes}"

--- a/Industrious.ToDo.ViewModels/ItemEditorViewModel.cs
+++ b/Industrious.ToDo.ViewModels/ItemEditorViewModel.cs
@@ -65,6 +65,15 @@ namespace Industrious.ToDo.ViewModels
 		}
 
 
+		private Boolean _shouldFocusTitle;
+
+		public Boolean ShouldFocusTitle
+		{
+			get => _shouldFocusTitle;
+			set => SetAndRaiseIfChanged(ref _shouldFocusTitle, value);
+		}
+
+
 		private String _title;
 
 		public String Title
@@ -113,7 +122,10 @@ namespace Industrious.ToDo.ViewModels
 			OnToDoItemPropertyChanged(null, null);
 
 			if (SelectedItem != null)
+			{
 				SelectedItem.PropertyChanged += OnToDoItemPropertyChanged;
+				ShouldFocusTitle = (Title.Length == 0);
+			}
 		}
 
 

--- a/Industrious.ToDo.iOS/Industrious.ToDo.iOS.csproj
+++ b/Industrious.ToDo.iOS/Industrious.ToDo.iOS.csproj
@@ -107,7 +107,7 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="4.2.0.815419" />
+    <PackageReference Include="Xamarin.Forms" Version="4.3.0.908675" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Industrious.ToDo.Forms\Industrious.ToDo.Forms.csproj">


### PR DESCRIPTION
Improve usability by automatically setting the input focus to the title field when creating new todos.

Fixes #13.